### PR TITLE
Tweaking the API and cleaning up

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -4,7 +4,7 @@ from dash import Dash
 from dash.dependencies import Input, Output, State, ALL
 from dash_core_components import Graph, Slider, Store
 
-from .utils import img_array_to_uri, get_thumbnail_size_from_shape, shape3d_to_size2d
+from .utils import img_array_to_uri, get_thumbnail_size, shape3d_to_size2d
 
 
 class VolumeSlicer:
@@ -88,9 +88,7 @@ class VolumeSlicer:
         }
 
         # Prep low-res slices
-        thumbnail_size = get_thumbnail_size_from_shape(
-            (info["size"][1], info["size"][0]), 32
-        )
+        thumbnail_size = get_thumbnail_size(info["size"][:2], (32, 32))
         thumbnails = [
             img_array_to_uri(self._slice(i), thumbnail_size)
             for i in range(info["size"][2])

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -15,26 +15,28 @@ class VolumeSlicer:
       volume (ndarray): the 3D numpy array to slice through. The dimensions
         are assumed to be in zyx order. If this is not the case, you can
         use ``np.swapaxes`` to make it so.
-      spacing (tuple of floats): The distance between voxels for each dimension (zyx).
-        The spacing and origin are applied to make the slice drawn in
-        "scene space" rather than "voxel space".
+      spacing (tuple of floats): The distance between voxels for each
+        dimension (zyx).The spacing and origin are applied to make the slice
+        drawn in "scene space" rather than "voxel space".
       origin (tuple of floats): The offset for each dimension (zyx).
       axis (int): the dimension to slice in. Default 0.
       reverse_y (bool): Whether to reverse the y-axis, so that the origin of
         the slice is in the top-left, rather than bottom-left. Default True.
-        (This sets the figure's yaxes ``autorange`` to either "reversed" or True.)
+        (This sets the figure's yaxes ``autorange`` to "reversed" or True.)
       scene_id (str): the scene that this slicer is part of. Slicers
         that have the same scene-id show each-other's positions with
         line indicators. By default this is derived from ``id(volume)``.
 
     This is a placeholder object, not a Dash component. The components
-    that make up the slicer can be accessed as attributes:
+    that make up the slicer can be accessed as attributes. These must all
+    be present in the app layout:
 
-    * ``graph``: the dcc.Graph object.
-    * ``graph.figure``: the Plotly figure object.
-    * ``slider``: the dcc.Slider object, its value represents the slice index.
-    * ``stores``: a list of dcc.Store objects. Some are "public" values, others
-      used internally. Make sure to put them somewhere in the layout.
+    * ``graph``: the dcc.Graph object. Use ``graph.figure`` to access the
+      Plotly figure object.
+    * ``slider``: the dcc.Slider object, its value represents the slice
+      index. If you don't want to use the slider, wrap it in a div with
+      style ``display: none``.
+    * ``stores``: a list of dcc.Store objects.
 
     """
 
@@ -71,7 +73,7 @@ class VolumeSlicer:
         self._axis = int(axis)
         self._reverse_y = bool(reverse_y)
 
-        # Check and store scene id
+        # Check and store scene id, and generate
         if scene_id is None:
             scene_id = "volume_" + hex(id(volume))[2:]
         elif not isinstance(scene_id, str):
@@ -128,7 +130,7 @@ class VolumeSlicer:
         return self._stores
 
     def _subid(self, name, use_dict=False):
-        """Given a subid, get the full id including the slicer's prefix."""
+        """Given a name, get the full id including the context id prefix."""
         if use_dict:
             # A dict-id is nice to query objects with pattern matching callbacks,
             # and we use that to show the position of other sliders. But it makes

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -144,13 +144,19 @@ class VolumeSlicer:
             updatemode="drag",
         )
         # Create the stores that we need (these must be present in the layout)
+        self._info = Store(id=self._subid("info"), data=info)
+        self._position = Store(id=self._subid("position"), data=0)
+        self._requested_slice = Store(id=self._subid("_requested-slice-index"), data=0)
+        self._request_data = Store(id=self._subid("_slice-data"), data="")
+        self._lowres_data = Store(id=self._subid("_slice-data-lowres"), data=thumbnails)
+        self._indicators = Store(id=self._subid("_indicators"), data=[])
         self.stores = [
-            Store(id=self._subid("info"), data=info),
-            Store(id=self._subid("position"), data=0),
-            Store(id=self._subid("_requested-slice-index"), data=0),
-            Store(id=self._subid("_slice-data"), data=""),
-            Store(id=self._subid("_slice-data-lowres"), data=thumbnails),
-            Store(id=self._subid("_indicators"), data=[]),
+            self._info,
+            self._position,
+            self._requested_slice,
+            self._request_data,
+            self._lowres_data,
+            self._indicators,
         ]
 
         self._create_server_callbacks()
@@ -179,8 +185,8 @@ class VolumeSlicer:
         app = self._app
 
         @app.callback(
-            Output(self._subid("_slice-data"), "data"),
-            [Input(self._subid("_requested-slice-index"), "data")],
+            Output(self._request_data.id, "data"),
+            [Input(self._requested_slice.id, "data")],
         )
         def upload_requested_slice(slice_index):
             slice = self._slice(slice_index)
@@ -196,9 +202,9 @@ class VolumeSlicer:
             return info.origin[2] + index * info.spacing[2];
         }
         """,
-            Output(self._subid("position"), "data"),
-            [Input(self._subid("slider"), "value")],
-            [State(self._subid("info"), "data")],
+            Output(self._position.id, "data"),
+            [Input(self.slider.id, "value")],
+            [State(self._info.id, "data")],
         )
 
         app.clientside_callback(
@@ -216,8 +222,8 @@ class VolumeSlicer:
         """.replace(
                 "{{ID}}", self.context_id
             ),
-            Output(self._subid("_requested-slice-index"), "data"),
-            [Input(self._subid("slider"), "value")],
+            Output(self._requested_slice.id, "data"),
+            [Input(self.slider.id, "value")],
         )
 
         # app.clientside_callback("""
@@ -270,16 +276,16 @@ class VolumeSlicer:
         """.replace(
                 "{{ID}}", self.context_id
             ),
-            Output(self._subid("graph"), "figure"),
+            Output(self.graph.id, "figure"),
             [
-                Input(self._subid("slider"), "value"),
-                Input(self._subid("_slice-data"), "data"),
-                Input(self._subid("_indicators"), "data"),
+                Input(self.slider.id, "value"),
+                Input(self._request_data.id, "data"),
+                Input(self._indicators.id, "data"),
             ],
             [
-                State(self._subid("graph"), "figure"),
-                State(self._subid("_slice-data-lowres"), "data"),
-                State(self._subid("info"), "data"),
+                State(self.graph.id, "figure"),
+                State(self._lowres_data.id, "data"),
+                State(self._info.id, "data"),
             ],
         )
 
@@ -320,7 +326,7 @@ class VolumeSlicer:
             };
         }
         """,
-            Output(self._subid("_indicators"), "data"),
+            Output(self._indicators.id, "data"),
             [
                 Input(
                     {
@@ -334,7 +340,7 @@ class VolumeSlicer:
                 for axis in axii
             ],
             [
-                State(self._subid("info"), "data"),
-                State(self._subid("_indicators"), "data"),
+                State(self._info.id, "data"),
+                State(self._indicators.id, "data"),
             ],
         )

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -25,14 +25,15 @@ class VolumeSlicer:
         (This sets the figure's yaxes ``autorange`` to either "reversed" or True.)
       scene_id (str): the scene that this slicer is part of. Slicers
         that have the same scene-id show each-other's positions with
-        line indicators. By default this is a hash of ``id(volume)``.
+        line indicators. By default this is derived from ``id(volume)``.
 
     This is a placeholder object, not a Dash component. The components
     that make up the slicer can be accessed as attributes:
 
-    * ``graph``: the Graph object.
-    * ``slider``: the Slider object.
-    * ``stores``: a list of Store objects. Some are "public" values, others
+    * ``graph``: the dcc.Graph object.
+    * ``graph.figure``: the Plotly figure object.
+    * ``slider``: the dcc.Slider object, its value represents the slice index.
+    * ``stores``: a list of dcc.Store objects. Some are "public" values, others
       used internally. Make sure to put them somewhere in the layout.
 
     Each component is given a dict-id with the following keys:

--- a/dash_slicer/utils.py
+++ b/dash_slicer/utils.py
@@ -1,5 +1,4 @@
 import io
-import random
 import base64
 
 import numpy as np
@@ -7,11 +6,8 @@ import PIL.Image
 import skimage
 
 
-def gen_random_id(n=6):
-    return "".join(random.choice("abcdefghijklmnopqrtsuvwxyz") for i in range(n))
-
-
 def img_array_to_uri(img_array, new_size=None):
+    """Convert the given image (numpy array) into a base64-encoded PNG."""
     img_array = skimage.util.img_as_ubyte(img_array)
     # todo: leverage this Plotly util once it becomes part of the public API (also drops the Pillow dependency)
     # from plotly.express._imshow import _array_to_b64str
@@ -26,11 +22,13 @@ def img_array_to_uri(img_array, new_size=None):
     return "data:image/png;base64," + base64_str
 
 
-def get_thumbnail_size_from_shape(shape, base_size):
-    base_size = int(base_size)
-    img_array = np.zeros(shape, np.uint8)
+def get_thumbnail_size(size, new_size):
+    """Given an image size (w, h), and a preferred smaller size,
+    get the actual size if we let Pillow downscale it.
+    """
+    img_array = np.zeros(list(reversed(size)), np.uint8)
     img_pil = PIL.Image.fromarray(img_array)
-    img_pil.thumbnail((base_size, base_size))
+    img_pil.thumbnail(new_size)
     return img_pil.size
 
 

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -1,0 +1,47 @@
+"""
+Bring your own slider ... or dropdown. This example shows how to use a
+different input element for the slice index. The slider's value is used
+as an output, but the slider element itself is hidden.
+"""
+
+import dash
+import dash_html_components as html
+import dash_core_components as dcc
+from dash.dependencies import Input, Output
+from dash_slicer import VolumeSlicer
+import imageio
+
+
+app = dash.Dash(__name__)
+
+vol = imageio.volread("imageio:stent.npz")
+slicer = VolumeSlicer(app, vol)
+
+dropdown = dcc.Dropdown(
+    id="dropdown",
+    options=[{"label": f"slice {i}", "value": i} for i in range(0, vol.shape[0], 10)],
+    value=50,
+)
+
+
+# Define the layout
+app.layout = html.Div(
+    [
+        slicer.graph,
+        dropdown,
+        html.Div(slicer.slider, style={"display": "none"}),
+        *slicer.stores,
+    ]
+)
+
+
+@app.callback(
+    Output(slicer.slider.id, "value"),
+    [Input(dropdown.id, "value")],
+)
+def handle_dropdown_input(index):
+    return index
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/examples/slicer_customized.py
+++ b/examples/slicer_customized.py
@@ -1,6 +1,6 @@
 """
-A small example showing how to write callbacks involving the slicer's
-components. The slicer's components are used as both inputs and outputs.
+An example showing how to customize the slicer and write callbacks
+involving the slicer's components.
 """
 
 import dash
@@ -15,10 +15,20 @@ app = dash.Dash(__name__)
 vol = imageio.volread("imageio:stent.npz")
 slicer = VolumeSlicer(app, vol)
 
+
 # We can access the components, and modify them
 slicer.slider.value = 0
 
-# Define the layour, including extra buttons
+# The graph can be configured
+slicer.graph.config.update({"modeBarButtonsToAdd": ["drawclosedpath", "eraseshape"]})
+
+# The plotly figure can be accessed too
+slicer.graph.figure.update_layout(margin=dict(l=0, r=0, b=30, t=0, pad=4))
+slicer.graph.figure.update_xaxes(showgrid=True, showticklabels=True)
+slicer.graph.figure.update_yaxes(showgrid=True, showticklabels=True)
+
+
+# Define the layout, including extra buttons
 app.layout = html.Div(
     [
         slicer.graph,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ NAME = "dash-slicer"
 SUMMARY = "A volume slicer for Dash"
 
 
-with open(f"{NAME}/__init__.py") as fh:
+with open(f"{NAME.replace('-', '_')}/__init__.py") as fh:
     VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
 
 

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,0 +1,47 @@
+from dash_slicer import VolumeSlicer
+
+import numpy as np
+from pytest import raises
+import dash
+import dash_core_components as dcc
+
+
+def test_slicer_init():
+    app = dash.Dash()
+
+    vol = np.random.uniform(0, 255, (100, 100, 100)).astype(np.uint8)
+
+    # Need a valid volume
+    with raises(TypeError):
+        VolumeSlicer(app, [3, 4, 5])
+    with raises(TypeError):
+        VolumeSlicer(app, vol[0])
+
+    # Need a valid axis
+    with raises(ValueError):
+        VolumeSlicer(app, vol, axis=4)
+
+    # This works
+    s = VolumeSlicer(app, vol)
+
+    # Check properties
+    assert isinstance(s.graph, dcc.Graph)
+    assert isinstance(s.slider, dcc.Slider)
+    assert isinstance(s.stores, list)
+    assert all(isinstance(store, dcc.Store) for store in s.stores)
+
+
+def test_scene_id_and_context_id():
+    app = dash.Dash()
+
+    vol = np.random.uniform(0, 255, (100, 100, 100)).astype(np.uint8)
+
+    s1 = VolumeSlicer(app, vol, axis=0)
+    s2 = VolumeSlicer(app, vol, axis=0)
+    s3 = VolumeSlicer(app, vol, axis=1)
+
+    # The scene id's are equal, so indicators will match up
+    assert s1.scene_id == s2.scene_id and s1.scene_id == s3.scene_id
+
+    # Context id's must be unique
+    assert s1.context_id != s2.context_id and s1.context_id != s3.context_id

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -44,4 +44,4 @@ def test_scene_id_and_context_id():
     assert s1.scene_id == s2.scene_id and s1.scene_id == s3.scene_id
 
     # Context id's must be unique
-    assert s1.context_id != s2.context_id and s1.context_id != s3.context_id
+    assert s1._context_id != s2._context_id and s1._context_id != s3._context_id

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,29 @@
-from dash_slicer.utils import shape3d_to_size2d
+from dash_slicer.utils import img_array_to_uri, get_thumbnail_size, shape3d_to_size2d
 
+import numpy as np
 from pytest import raises
+
+
+def test_img_array_to_uri():
+
+    im = np.random.uniform(0, 255, (100, 100)).astype(np.uint8)
+
+    r1 = img_array_to_uri(im)
+    r2 = img_array_to_uri(im, (32, 32))
+    r3 = img_array_to_uri(im, (8, 8))
+
+    for r in (r1, r2, r3):
+        assert isinstance(r, str)
+        assert r.startswith("data:image/png;base64,")
+
+    assert len(r1) > len(r2) > len(r3)
+
+
+def test_get_thumbnail_size():
+
+    assert get_thumbnail_size((100, 100), (16, 16)) == (16, 16)
+    assert get_thumbnail_size((50, 100), (16, 16)) == (8, 16)
+    assert get_thumbnail_size((100, 100), (8, 16)) == (8, 8)
 
 
 def test_shape3d_to_size2d():


### PR DESCRIPTION
* [x] Use str id's for most components. Closes #9.
* [x] Add example to use a different input component as the slider.
* [x] Clean up the docs.
* [x] Show more config options in one example. Closes #6.
* [x] Add tests.
* [x] Public attributes are now `@properties`, for clarity and better documenting.