### PR TITLE
Enable navigating by clicking

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn examples.threshold_overlay:server
+web: gunicorn examples.slicer_with_3_views:server

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -245,7 +245,7 @@ class VolumeSlicer:
         fig.update_layout(
             template=None,
             margin={"l": 0, "r": 0, "b": 0, "t": 0, "pad": 4},
-            dragmode="pan",  # user navigates by panning
+            dragmode="pan",  # good default mode
         )
         fig.update_xaxes(
             showgrid=False,
@@ -283,10 +283,7 @@ class VolumeSlicer:
         self._position = Store(
             id=self._subid("position", True, axis=self._axis), data=0
         )
-        self._setpos = Store(id=self._subid("setpos", True, foo=1), data=None)
-        self._setpos2 = Store(
-            id=self._subid("setpos", True, foo=2), data=None
-        )  # temporary to have both click and pan working
+        self._setpos = Store(id=self._subid("setpos", True), data=None)
         self._requested_index = Store(id=self._subid("req-index"), data=0)
         self._request_data = Store(id=self._subid("req-data"), data="")
         self._lowres_data = Store(id=self._subid("lowres"), data=thumbnails)
@@ -297,7 +294,6 @@ class VolumeSlicer:
             self._info,
             self._position,
             self._setpos,
-            self._setpos2,
             self._requested_index,
             self._request_data,
             self._lowres_data,
@@ -344,33 +340,6 @@ class VolumeSlicer:
         )
 
         # ----------------------------------------------------------------------
-        # xxxxxxxxxxxxxxxxxxxxxxxx
-
-        app.clientside_callback(
-            """
-        function handle_panzoom(data, index, figure, info) {
-            if (data && !data['xaxis.range[0]'] && !data['yaxis.range[0]']) return dash_clientside.no_update;
-            let xrange = figure.layout.xaxis.range;
-            let yrange = figure.layout.yaxis.range;
-            if (!xrange || !yrange) return dash_clientside.no_update;
-            window.figure = figure;
-            let xyz = [(xrange[0] + xrange[1])/2, (yrange[0] + yrange[1])/2];
-            let depth = info.origin[2] + index * info.spacing[2];
-            xyz.splice(2 - info.axis, 0, depth);
-            return xyz;
-            //return dash_clientside.no_update;
-        }
-        """,
-            Output(self._setpos2.id, "data"),
-            [Input(self._graph.id, "relayoutData")],
-            [
-                State(self._slider.id, "value"),
-                State(self.graph.id, "figure"),
-                State(self._info.id, "data"),
-            ],
-        )
-
-        # ----------------------------------------------------------------------
         # Callback to update index from external setpos signal.
 
         app.clientside_callback(
@@ -393,7 +362,6 @@ class VolumeSlicer:
                     {
                         "scene": self._scene_id,
                         "context": ALL,
-                        "foo": ALL,  # todo: remove this temp thingy
                         "name": "setpos",
                     },
                     "data",
@@ -583,32 +551,10 @@ class VolumeSlicer:
             for (let trace of img_traces) { traces.push(trace); }
             for (let trace of indicators) { traces.push(trace); }
 
-            let crosshair1 = {
-                type:'line',
-                line: {color:'yellow', width:1},
-                xref: 'paper',
-                yref: 'paper',
-                x0: 0.475,
-                x1: 0.525,
-                y0: 0.5,
-                y1: 0.5
-            };
-            let crosshair2 = {
-                type:'line',
-                line: {color:'yellow', width:1},
-                xref: 'paper',
-                yref: 'paper',
-                x0: 0.5,
-                x1: 0.5,
-                y0: 0.475,
-                y1: 0.525
-            };
-
             // Update figure
             console.log("updating figure");
             let figure = {...ori_figure};
             figure.data = traces;
-            figure.layout.shapes = [crosshair1, crosshair2];
 
             return figure;
         }

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -343,12 +343,13 @@ class VolumeSlicer:
 
         app.clientside_callback(
             """
-        function respond_to_setpos(indices, info) {
+        function respond_to_setpos(indices, cur_index, info) {
             for (let trigger of dash_clientside.callback_context.triggered) {
                 if (!trigger.value) continue;
                 let pos = trigger.value[2 - info.axis];
                 if (typeof pos !== 'number') continue;
                 let index = Math.round((pos - info.origin[2]) / info.spacing[2]);
+                if (index == cur_index) continue;
                 return Math.max(0, Math.min(info.size[2] - 1, index));
             }
             return dash_clientside.no_update;
@@ -365,7 +366,7 @@ class VolumeSlicer:
                     "data",
                 )
             ],
-            [State(self._info.id, "data")],
+            [State(self._slider.id, "value"), State(self._info.id, "data")],
         )
 
         # ----------------------------------------------------------------------

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -38,6 +38,15 @@ class VolumeSlicer:
       style ``display: none``.
     * ``stores``: a list of dcc.Store objects.
 
+    To programatically set the position of the slicer, use a store with
+    a dictionary-id with the following fields:
+
+    * 'context': a unique name for this store.
+    * 'scene': the scene_id for which to set the position
+    * 'name': 'setpos'
+
+    The value in the store must be an 3-element tuple (x, y, z) in scene coordinates.
+    To apply the position for one position only, use e.g ``(None, None, x)``.
     """
 
     _global_slicer_counter = 0
@@ -338,6 +347,7 @@ class VolumeSlicer:
             for (let trigger of dash_clientside.callback_context.triggered) {
                 if (!trigger.value) continue;
                 let pos = trigger.value[2 - info.axis];
+                if (typeof pos !== 'number') continue;
                 let index = Math.round((pos - info.origin[2]) / info.spacing[2]);
                 return Math.max(0, Math.min(info.size[2] - 1, index));
             }

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -1,7 +1,9 @@
 """
 Bring your own slider ... or dropdown. This example shows how to use a
-different input element for the slice index. The slider's value is used
-as an output, but the slider element itself is hidden.
+different input element for the slice position. A store is created with
+certain predefined elements. The value set to this store is an xyz
+position in scene coordinates. None can be used to ignore certain
+dimensions. The slider element itself is hidden.
 """
 
 import dash
@@ -17,6 +19,10 @@ app = dash.Dash(__name__)
 vol = imageio.volread("imageio:stent.npz")
 slicer = VolumeSlicer(app, vol)
 
+setpos_store = dcc.Store(
+    id={"context": "app", "scene": slicer.scene_id, "name": "setpos"}
+)
+
 dropdown = dcc.Dropdown(
     id="dropdown",
     options=[{"label": f"slice {i}", "value": i} for i in range(0, vol.shape[0], 10)],
@@ -30,17 +36,18 @@ app.layout = html.Div(
         slicer.graph,
         dropdown,
         html.Div(slicer.slider, style={"display": "none"}),
+        setpos_store,
         *slicer.stores,
     ]
 )
 
 
 @app.callback(
-    Output(slicer.slider.id, "value"),
+    Output(setpos_store.id, "data"),
     [Input(dropdown.id, "value")],
 )
 def handle_dropdown_input(index):
-    return index
+    return None, None, index  # xyz in scene coords
 
 
 if __name__ == "__main__":

--- a/examples/slicer_customized.py
+++ b/examples/slicer_customized.py
@@ -5,6 +5,7 @@ involving the slicer's components.
 
 import dash
 import dash_html_components as html
+import dash_core_components as dcc
 from dash.dependencies import Input, Output, State
 from dash_slicer import VolumeSlicer
 import imageio
@@ -17,7 +18,7 @@ slicer = VolumeSlicer(app, vol)
 
 
 # We can access the components, and modify them
-slicer.slider.value = 0
+slicer.slider.value = 10
 
 # The graph can be configured
 slicer.graph.config.update({"modeBarButtonsToAdd": ["drawclosedpath", "eraseshape"]})
@@ -26,6 +27,10 @@ slicer.graph.config.update({"modeBarButtonsToAdd": ["drawclosedpath", "eraseshap
 slicer.graph.figure.update_layout(margin=dict(l=0, r=0, b=30, t=0, pad=4))
 slicer.graph.figure.update_xaxes(showgrid=True, showticklabels=True)
 slicer.graph.figure.update_yaxes(showgrid=True, showticklabels=True)
+
+setpos_store = dcc.Store(
+    id={"context": "app", "scene": slicer.scene_id, "name": "setpos"}
+)
 
 
 # Define the layout, including extra buttons
@@ -42,6 +47,7 @@ app.layout = html.Div(
                 html.Button(">", id="increase-index"),
             ],
         ),
+        setpos_store,
         *slicer.stores,
     ]
 )
@@ -58,7 +64,7 @@ def show_slider_value(index):
 
 
 @app.callback(
-    Output(slicer.slider.id, "value"),
+    Output(setpos_store.id, "data"),
     [Input("decrease-index", "n_clicks"), Input("increase-index", "n_clicks")],
     [State(slicer.slider.id, "value")],
 )
@@ -66,7 +72,7 @@ def handle_button_input(press1, press2, index):
     ctx = dash.callback_context
     if ctx.triggered:
         index += 1 if "increase" in ctx.triggered[0]["prop_id"] else -1
-    return index
+    return None, None, index  # xyz in scene coords
 
 
 if __name__ == "__main__":

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -25,7 +25,7 @@ vol1 = imageio.volread("imageio:stent.npz")
 
 vol2 = vol1[::3, ::2, :]
 spacing = 3, 2, 1
-ori = 110, 120, 140
+ori = 1000, 2000, 3000
 
 
 slicer1 = VolumeSlicer(

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -12,6 +12,7 @@ from skimage.measure import marching_cubes
 import imageio
 
 app = dash.Dash(__name__)
+server = app.server
 
 # Read volumes and create slicer objects
 vol = imageio.volread("imageio:stent.npz")

--- a/test_deploy/requirements.txt
+++ b/test_deploy/requirements.txt
@@ -5,3 +5,4 @@ dash
 dash_core_components
 imageio
 gunicorn
+scikit-image


### PR DESCRIPTION
Closes #16

In short:
* When the graph is clicked, we set the 3D position of that click in a store. This store as a dict id.
* Each slider uses a callback with a pattern matching input to listen to these position-set-signals.
* This callback selects the dimension that applies to the current slicer, and convert the position to an index, then sets the slider value.

The disadvantage is that application code can no longer use the slider value as output, but that felt kinda iffy anyway. The new approach is for users to create a store with a similar dict-id. The advantage of this is that the slicer positions can be set from multiple sources!

