### PR TITLE
Add a rate limiter on the slicer's index

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -276,43 +276,66 @@ class VolumeSlicer:
             config={"scrollZoom": True},
         )
 
-        # Create a slider object that the user can put in the layout (or not)
+        initial_index = info["size"][2] // 2
+        initial_pos = info["origin"][2] + initial_index * info["spacing"][2]
+
+        # Create a slider object that the user can put in the layout (or not).
         self._slider = Slider(
             id=self._subid("slider"),
             min=0,
             max=info["size"][2] - 1,
             step=1,
-            value=info["size"][2] // 2,
+            value=initial_index,
             tooltip={"always_visible": False, "placement": "left"},
             updatemode="drag",
         )
 
         # Create the stores that we need (these must be present in the layout)
+
+        # A dict of static info for this slicer
         self._info = Store(id=self._subid("info"), data=info)
-        self._position = Store(
-            id=self._subid("position", True, axis=self._axis), data=0
-        )
-        self._setpos = Store(id=self._subid("setpos", True), data=None)
-        self._requested_index = Store(id=self._subid("req-index"), data=0)
-        self._request_data = Store(id=self._subid("req-data"), data="")
+
+        # A list of low-res slices (encoded as base64-png)
         self._lowres_data = Store(id=self._subid("lowres"), data=thumbnails)
+
+        # A list of mask slices (encoded as base64-png or null)
         self._overlay_data = Store(id=self._subid("overlay"), data=[])
+
+        # Slice data provided by the server
+        self._server_data = Store(id=self._subid("server-data"), data="")
+
+        # Store image traces for the slicer.
         self._img_traces = Store(id=self._subid("img-traces"), data=[])
+
+        # Store indicator traces for the slicer.
         self._indicator_traces = Store(id=self._subid("indicator-traces"), data=[])
-        self._interval = Interval(
-            id=self._subid("interval"), interval=100, disabled=True
+
+        # An timer to apply a rate-limit between slider.value and index.data
+        self._timer = Interval(id=self._subid("timer"), interval=100, disabled=True)
+
+        # The (integer) index of the slice to show. This value is rate-limited
+        self._index = Store(id=self._subid("index"), data=initial_index)
+
+        # The (float) position (in scene coords) of the current slice,
+        # used to publish our position to slicers with the same scene_id.
+        self._pos = Store(
+            id=self._subid("pos", True, axis=self._axis), data=initial_pos
         )
+
+        # Signal to set the position of other slicers with the same scene_id.
+        self._setpos = Store(id=self._subid("setpos", True), data=None)
+
         self._stores = [
             self._info,
-            self._position,
-            self._setpos,
-            self._requested_index,
-            self._request_data,
             self._lowres_data,
             self._overlay_data,
+            self._server_data,
             self._img_traces,
             self._indicator_traces,
-            self._interval,
+            self._timer,
+            self._index,
+            self._pos,
+            self._setpos,
         ]
 
     def _create_server_callbacks(self):
@@ -320,8 +343,8 @@ class VolumeSlicer:
         app = self._app
 
         @app.callback(
-            Output(self._request_data.id, "data"),
-            [Input(self._requested_index.id, "data")],
+            Output(self._server_data.id, "data"),
+            [Input(self._index.id, "data")],
         )
         def upload_requested_slice(slice_index):
             slice = img_array_to_uri(self._slice(slice_index))
@@ -329,14 +352,29 @@ class VolumeSlicer:
 
     def _create_client_callbacks(self):
         """Create the callbacks that run client-side."""
+
+        # setpos (external)
+        #     \
+        #     slider  --[rate limit]-->  index  -->  pos
+        #         \                         \
+        #          \                   server_data (a new slice)
+        #           \                         \
+        #            \                         -->  image_traces
+        #             ----------------------- /           \
+        #                                                  ----->  figure
+        #                                                 /
+        #                                      indicator_traces
+        #                                               /
+        #                                             pos (external)
+
         app = self._app
 
         # ----------------------------------------------------------------------
-        # Callback to trigger fellow slicers to go to a specific position.
+        # Callback to trigger fellow slicers to go to a specific position on click.
 
         app.clientside_callback(
             """
-        function trigger_setpos(data, index, info) {
+        function update_setpos_from_click(data, index, info) {
             if (data && data.points && data.points.length) {
                 let point = data["points"][0];
                 let xyz = [point["x"], point["y"]];
@@ -353,11 +391,11 @@ class VolumeSlicer:
         )
 
         # ----------------------------------------------------------------------
-        # Callback to update index from external setpos signal.
+        # Callback to update slider based on external setpos signals.
 
         app.clientside_callback(
             """
-        function respond_to_setpos(positions, cur_index, info) {
+        function update_slider_value(positions, cur_index, info) {
             for (let trigger of dash_clientside.callback_context.triggered) {
                 if (!trigger.value) continue;
                 let pos = trigger.value[2 - info.axis];
@@ -384,29 +422,11 @@ class VolumeSlicer:
         )
 
         # ----------------------------------------------------------------------
-        # Callback to update position (in scene coordinates) from the index.
+        # Callback to rate-limit the index (using a timer/interval).
 
         app.clientside_callback(
             """
-        function update_position(index, info) {
-            return info.origin[2] + index * info.spacing[2];
-        }
-        """.replace(
-                "{{ID}}", self._context_id
-            ),
-            Output(self._position.id, "data"),
-            [Input(self._requested_index.id, "data")],
-            [State(self._info.id, "data")],
-        )
-
-        # ----------------------------------------------------------------------
-        # Callback to request new slices.
-        # Note: this callback cannot be merged with the one below, because
-        # it would create a circular dependency.
-
-        app.clientside_callback(
-            """
-        function rate_limit_index(index, _, interval) {
+        function update_index_by_rate_limiting_the_slider_value(index, n_intervals, interval) {
             if (!window._slicer_{{ID}}) window._slicer_{{ID}} = {};
             let slicer_info = window._slicer_{{ID}};
             let now = window.performance.now();
@@ -419,13 +439,15 @@ class VolumeSlicer:
 
             // Initialize return values
             let req_index = dash_clientside.no_update;
-            let disable_interval = false;
+            let disable_timer = false;
 
             // If the slider moved, remember the time when this happened
             slicer_info.new_time = slicer_info.new_time || 0;
 
             if (slider_was_moved) {
                 slicer_info.new_time = now;
+            } else if (!n_intervals) {
+                disable_timer = true;  // start disabled
             }
 
             // We can either update the rate-limited index interval ms after
@@ -434,12 +456,12 @@ class VolumeSlicer:
             // dragging the slider, the latter is better for a smooth
             // experience, and the interval can be set much lower.
             if (index != slicer_info.req_index) {
-                if (now - slicer_info.new_time >= interval) {
+                if (now - slicer_info.new_time >= interval * 2) {
                     req_index = slicer_info.req_index = index;
-                    disable_interval = true;
+                    disable_timer = true;
 
                     // Get cache
-                    // todo: _requested_index is now our rate-limited index, so we need to always apply
+                    // todo: _index is now our rate-limited index, so we need to always apply
                     //if (!window.slicecache_for_{{ID}}) { window.slicecache_for_{{ID}} = {}; }
                     //let slice_cache = window.slicecache_for_{{ID}};
                     //if (slice_cache[req_index]) {
@@ -450,17 +472,33 @@ class VolumeSlicer:
                 }
             }
 
-            return [req_index, disable_interval];
+            return [req_index, disable_timer];
         }
         """.replace(
                 "{{ID}}", self._context_id
             ),
             [
-                Output(self._requested_index.id, "data"),
-                Output(self._interval.id, "disabled"),
+                Output(self._index.id, "data"),
+                Output(self._timer.id, "disabled"),
             ],
-            [Input(self._slider.id, "value"), Input(self._interval.id, "n_intervals")],
-            [State(self._interval.id, "interval")],
+            [Input(self._slider.id, "value"), Input(self._timer.id, "n_intervals")],
+            [State(self._timer.id, "interval")],
+        )
+
+        # ----------------------------------------------------------------------
+        # Callback to update position (in scene coordinates) from the index.
+
+        app.clientside_callback(
+            """
+        function update_pos(index, info) {
+            return info.origin[2] + index * info.spacing[2];
+        }
+        """.replace(
+                "{{ID}}", self._context_id
+            ),
+            Output(self._pos.id, "data"),
+            [Input(self._index.id, "data")],
+            [State(self._info.id, "data")],
         )
 
         # ----------------------------------------------------------------------
@@ -468,14 +506,14 @@ class VolumeSlicer:
 
         app.clientside_callback(
             """
-        function update_image_traces(index, req_data, overlays, lowres, info, current_traces) {
+        function update_image_traces(index, server_data, overlays, lowres, info, current_traces) {
 
             // Add data to the cache if the data is indeed new
             if (!window.slicecache_for_{{ID}}) { window.slicecache_for_{{ID}} = {}; }
             let slice_cache = window.slicecache_for_{{ID}};
             for (let trigger of dash_clientside.callback_context.triggered) {
-                if (trigger.prop_id.indexOf('req-data') >= 0) {
-                    slice_cache[req_data.index] = req_data;
+                if (trigger.prop_id.indexOf('server-data') >= 0) {
+                    slice_cache[server_data.index] = server_data;
                     break;
                 }
             }
@@ -524,7 +562,7 @@ class VolumeSlicer:
             Output(self._img_traces.id, "data"),
             [
                 Input(self._slider.id, "value"),
-                Input(self._request_data.id, "data"),
+                Input(self._server_data.id, "data"),
                 Input(self._overlay_data.id, "data"),
             ],
             [
@@ -536,13 +574,13 @@ class VolumeSlicer:
 
         # ----------------------------------------------------------------------
         # Callback to create scatter traces from the positions of other slicers.
-
-        # Create a callback to create a trace representing all slice-indices that:
+        # Creatse a trace representing all slice-indices that:
         # * corresponding to the same volume data
         # * match any of the selected axii
+
         app.clientside_callback(
             """
-        function handle_indicator(positions1, positions2, info, current) {
+        function update_indicator_traces(positions1, positions2, info, current) {
             let x0 = info.origin[0], y0 = info.origin[1];
             let x1 = x0 + info.size[0] * info.spacing[0], y1 = y0 + info.size[1] * info.spacing[1];
             x0 = x0 - info.spacing[0], y0 = y0 - info.spacing[1];
@@ -576,7 +614,7 @@ class VolumeSlicer:
                     {
                         "scene": self._scene_id,
                         "context": ALL,
-                        "name": "position",
+                        "name": "pos",
                         "axis": axis,
                     },
                     "data",
@@ -602,7 +640,6 @@ class VolumeSlicer:
             for (let trace of indicators) { traces.push(trace); }
 
             // Update figure
-            console.log("updating figure");
             let figure = {...ori_figure};
             figure.data = traces;
 

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -330,7 +330,7 @@ class VolumeSlicer:
         # Store indicator traces for the slicer.
         self._indicator_traces = Store(id=self._subid("indicator-traces"), data=[])
 
-        # An timer to apply a rate-limit between slider.value and index.data
+        # A timer to apply a rate-limit between slider.value and index.data
         self._timer = Interval(id=self._subid("timer"), interval=100, disabled=True)
 
         # The (integer) index of the slice to show. This value is rate-limited

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -26,6 +26,7 @@ class VolumeSlicer:
       reverse_y (bool): Whether to reverse the y-axis, so that the origin of
         the slice is in the top-left, rather than bottom-left. Default True.
         (This sets the figure's yaxes ``autorange`` to "reversed" or True.)
+        Note: setting this to False affects performance, see #12.
       scene_id (str): the scene that this slicer is part of. Slicers
         that have the same scene-id show each-other's positions with
         line indicators. By default this is derived from ``id(volume)``.

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -14,7 +14,7 @@ from dash_slicer import VolumeSlicer
 import imageio
 
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 
 vol = imageio.volread("imageio:stent.npz")
 slicer = VolumeSlicer(app, vol)

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -28,14 +28,10 @@ spacing = 3, 2, 1
 ori = 1000, 2000, 3000
 
 
-slicer1 = VolumeSlicer(
-    app, vol1, axis=1, origin=ori, reverse_y=False, scene_id="scene1"
-)
-slicer2 = VolumeSlicer(
-    app, vol1, axis=0, origin=ori, reverse_y=False, scene_id="scene1"
-)
+slicer1 = VolumeSlicer(app, vol1, axis=1, origin=ori, scene_id="scene1")
+slicer2 = VolumeSlicer(app, vol1, axis=0, origin=ori, scene_id="scene1")
 slicer3 = VolumeSlicer(
-    app, vol2, axis=0, origin=ori, spacing=spacing, reverse_y=False, scene_id="scene1"
+    app, vol2, axis=0, origin=ori, spacing=spacing, scene_id="scene1"
 )
 
 app.layout = html.Div(

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -19,7 +19,7 @@ from dash_slicer import VolumeSlicer
 import imageio
 
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 
 vol1 = imageio.volread("imageio:stent.npz")
 

--- a/examples/slicer_with_2_views.py
+++ b/examples/slicer_with_2_views.py
@@ -8,7 +8,7 @@ from dash_slicer import VolumeSlicer
 import imageio
 
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 
 vol = imageio.volread("imageio:stent.npz")
 slicer1 = VolumeSlicer(app, vol, axis=1)

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -11,7 +11,7 @@ from dash_slicer import VolumeSlicer
 from skimage.measure import marching_cubes
 import imageio
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 server = app.server
 
 # Read volumes and create slicer objects

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -16,9 +16,9 @@ server = app.server
 
 # Read volumes and create slicer objects
 vol = imageio.volread("imageio:stent.npz")
-slicer1 = VolumeSlicer(app, vol, reverse_y=False, axis=0)
-slicer2 = VolumeSlicer(app, vol, reverse_y=False, axis=1)
-slicer3 = VolumeSlicer(app, vol, reverse_y=False, axis=2)
+slicer1 = VolumeSlicer(app, vol, axis=0)
+slicer2 = VolumeSlicer(app, vol, axis=1)
+slicer3 = VolumeSlicer(app, vol, axis=2)
 
 # Calculate isosurface and create a figure with a mesh object
 verts, faces, _, _ = marching_cubes(vol, 300, step_size=2)

--- a/examples/threshold_overlay.py
+++ b/examples/threshold_overlay.py
@@ -15,7 +15,7 @@ import numpy as np
 import imageio
 
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 server = app.server
 
 vol = imageio.volread("imageio:stent.npz")

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -28,7 +28,7 @@ def test_slicer_init():
     assert isinstance(s.graph, dcc.Graph)
     assert isinstance(s.slider, dcc.Slider)
     assert isinstance(s.stores, list)
-    assert all(isinstance(store, dcc.Store) for store in s.stores)
+    assert all(isinstance(store, (dcc.Store, dcc.Interval)) for store in s.stores)
 
 
 def test_scene_id_and_context_id():


### PR DESCRIPTION
Following up on #23, this PR improves the user experience by trying to keep the effect of a fast-changing index local to the current slicer. While dragging the slider, the current slicer is updated, but the other slicers (for the same scene_id) are not notified, nor will there be a request for new data to the server. When you stop dragging, the final value is "published", so the indicators update and the server provides the full-res data. This means all CPU cycles can be used to keep the current slicer responsive.

This is implemented using an Interval object that is turned on when the slider value is changed, and turned off when the value is published. The interval can be set to just 100ms so there is no perceived waiting time. Note that the behavior is pretty similar to the proposed approach in https://github.com/plotly/dash-core-components/pull/884.

In this PR:
* [x] The `slider.value` is rate-limited (with a dcc.Interval) into a store called "index".
* [x] Renamed some of the private stores, reordered them, and add more documentation for them.
* [x] Add note in docs about performance of `reverse_y=False`, and don't use it in our examples (for now).
* [x] Turn of the part of debugging mode that mad things slow :)
* [x] More tweaks
* [x] Remove caching, made #27 to track for future



