### PR TITLE
Improve performance

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -50,6 +50,10 @@ class VolumeSlicer:
 
     The value in the store must be an 3-element tuple (x, y, z) in scene coordinates.
     To apply the position for one position only, use e.g ``(None, None, x)``.
+
+    Some notes on performance: for a smooth experience, create the `Dash`
+    application with `update_title=None`, and when running the server in debug
+    mode, consider setting `dev_tools_props_check=False`.
     """
 
     _global_slicer_counter = 0

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -51,5 +51,5 @@ def handle_dropdown_input(index):
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -51,4 +51,5 @@ def handle_dropdown_input(index):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/slicer_customized.py
+++ b/examples/slicer_customized.py
@@ -76,4 +76,5 @@ def handle_button_input(press1, press2, index):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/slicer_customized.py
+++ b/examples/slicer_customized.py
@@ -76,5 +76,5 @@ def handle_button_input(press1, press2, index):
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -74,5 +74,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -74,4 +74,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/slicer_with_1_view.py
+++ b/examples/slicer_with_1_view.py
@@ -8,7 +8,7 @@ from dash_slicer import VolumeSlicer
 import imageio
 
 
-app = dash.Dash(__name__)
+app = dash.Dash(__name__, update_title=None)
 
 vol = imageio.volread("imageio:stent.npz")
 slicer = VolumeSlicer(app, vol)
@@ -17,5 +17,5 @@ app.layout = html.Div([slicer.graph, slicer.slider, *slicer.stores])
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/slicer_with_1_view.py
+++ b/examples/slicer_with_1_view.py
@@ -17,4 +17,5 @@ app.layout = html.Div([slicer.graph, slicer.slider, *slicer.stores])
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/slicer_with_2_views.py
+++ b/examples/slicer_with_2_views.py
@@ -43,5 +43,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/slicer_with_2_views.py
+++ b/examples/slicer_with_2_views.py
@@ -43,4 +43,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -69,5 +69,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -69,4 +69,5 @@ app.layout = html.Div(
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/threshold_overlay.py
+++ b/examples/threshold_overlay.py
@@ -62,4 +62,5 @@ def apply_levels(level):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects the performance of VolumeSlicer
+    app.run_server(debug=False)

--- a/examples/threshold_overlay.py
+++ b/examples/threshold_overlay.py
@@ -62,5 +62,5 @@ def apply_levels(level):
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects the performance of VolumeSlicer
-    app.run_server(debug=False)
+    # Note: dev_tools_props_check negatively affects the performance of VolumeSlicer
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/tests/performance1.py
+++ b/tests/performance1.py
@@ -146,4 +146,5 @@ function update_figure(index, option, ori_figure, data_list, data_png) {
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects performance
+    app.run_server(debug=False)

--- a/tests/performance1.py
+++ b/tests/performance1.py
@@ -146,5 +146,5 @@ function update_figure(index, option, ori_figure, data_list, data_png) {
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects performance
-    app.run_server(debug=False)
+    # Note that the dev_tools_props_check negatively affects performance
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/tests/performance2.py
+++ b/tests/performance2.py
@@ -120,4 +120,3 @@ function update_figure(index, ori_figure, data_png) {
 if __name__ == "__main__":
     # Note that debug mode negatively affects performance
     app.run_server(debug=False)
-

--- a/tests/performance2.py
+++ b/tests/performance2.py
@@ -52,6 +52,7 @@ app.layout = html.Div(
         html.Br(),
         dcc.Graph(id="graph", figure=fig),
         dcc.Store(id="index", data=0),
+        dcc.Store(id="trace", data=None),
         dcc.Store(id="data_png", data=slices_png),
     ]
 )
@@ -72,7 +73,19 @@ function update_index(index) {
 
 app.clientside_callback(
     """
-function update_figure(index, ori_figure, data_png) {
+function update_trace(index, data_png) {
+    return {type: 'image', source: data_png[index]};
+}
+""",
+    Output("trace", "data"),
+    [Input("index", "data")],
+    [State("data_png", "data")],
+)
+
+
+app.clientside_callback(
+    """
+function update_figure(trace, ori_figure) {
 
     // Get FPS
     let fps_result = dash_clientside.no_update;
@@ -91,13 +104,11 @@ function update_figure(index, ori_figure, data_png) {
     let figure_result = dash_clientside.no_update;
 
     if (true) {
-        let trace = {type: 'image', source: data_png[index]};
         figure_result = {...ori_figure};
         figure_result.layout.yaxis.range = [128, 0];
         figure_result.data = [trace];
     } else {
         // unfavorable y-axis
-        let trace = {type: 'image', source: data_png[index]};
         figure_result = {...ori_figure};
         figure_result.layout.yaxis.range = [0, 128];
         figure_result.data = [trace];
@@ -106,17 +117,11 @@ function update_figure(index, ori_figure, data_png) {
 }
 """,
     [Output("graph", "figure"), Output("fps", "children")],
-    [
-        # Input("index", "data")],
-        Input("slider", "value")
-    ],
-    [
-        State("graph", "figure"),
-        State("data_png", "data"),
-    ],
+    [Input("trace", "data")],
+    [State("graph", "figure")],
 )
 
 
 if __name__ == "__main__":
-    # Note that debug mode negatively affects performance
-    app.run_server(debug=False)
+    # Note that the dev_tools_props_check negatively affects performance
+    app.run_server(debug=True, dev_tools_props_check=False)

--- a/tests/performance2.py
+++ b/tests/performance2.py
@@ -118,4 +118,6 @@ function update_figure(index, ori_figure, data_png) {
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    # Note that debug mode negatively affects performance
+    app.run_server(debug=False)
+


### PR DESCRIPTION
Last time I totally overlooked the effect of debug mode on the performance. The benchmarks perform much better now :)

I also saw that with debug mode there seems to be quite some added overhead per callback, even if that callback just passes a value from an input to an output. 

The debug feature most responsible for the performance penalty here seems to be `dev_tools_props_check`, so you can also disable that, and still benefit from other debug features 🚀 

Running `tests/performance1.py` now gives me:
* noop: 60-90 fps
* empty: 70- fps
* heatmap: 10 fps
* heatmapgl: 13 fps
* png: 36-40 fps
* png not reversed: 10 fps

