### PR TITLE
Add support for setting indicator color

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -503,12 +503,16 @@ class VolumeSlicer:
             xrangeFig = [Math.min(xrangeFig[0], xrangeFig[1]), Math.max(xrangeFig[0], xrangeFig[1])];
             yrangeFig = [Math.min(yrangeFig[0], yrangeFig[1]), Math.max(yrangeFig[0], yrangeFig[1])];
 
-            // Add a little offset to avoid the corner-indicators for THIS slicer to
-            // only be half-visible. The 400 is an estimate of the figure width/height.
-            xrangeFig[0] += 2 * (xrangeFig[1] - xrangeFig[0]) / 400;
-            xrangeFig[1] -= 2 * (xrangeFig[1] - xrangeFig[0]) / 400;
-            yrangeFig[0] += 2 * (yrangeFig[1] - yrangeFig[0]) / 400;
-            yrangeFig[1] -= 2 * (yrangeFig[1] - yrangeFig[0]) / 400;
+            // Add offset to avoid the corner-indicators for THIS slicer to only be half-visible
+            let plotSize = [400, 400];  // This estimate results in ok results
+            let graphDiv = document.getElementById('{{ID}}-graph');
+            let plotDiv = graphDiv.getElementsByClassName('js-plotly-plot')[0];
+            if (plotDiv && plotDiv._fullLayout)
+                plotSize = [plotDiv._fullLayout.width, plotDiv._fullLayout.height];
+            xrangeFig[0] += 2 * (xrangeFig[1] - xrangeFig[0]) / plotSize[0];
+            xrangeFig[1] -= 2 * (xrangeFig[1] - xrangeFig[0]) / plotSize[0];
+            yrangeFig[0] += 2 * (yrangeFig[1] - yrangeFig[0]) / plotSize[1];
+            yrangeFig[1] -= 2 * (yrangeFig[1] - yrangeFig[0]) / plotSize[1];
 
             // Combine the ranges
             let xrange = [Math.max(xrangeVol[0], xrangeFig[0]), Math.min(xrangeVol[1], xrangeFig[1])];

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -656,17 +656,19 @@ class VolumeSlicer:
             // Show our own color as a rectangle around the image,
             // But only if there are multiple slicers with the same scene id.
             if (indicators.length > 1) {
-                let x0 = info.origin[0] - info.spacing[0]/2;
-                let y0 = info.origin[1] - info.spacing[1]/2;
-                let x1 = info.origin[0] + (info.size[0] - 0.5) * info.spacing[0];
-                let y1 = info.origin[1] + (info.size[1] - 0.5) * info.spacing[1];
+                let x1 = info.origin[0] - info.spacing[0]/2;
+                let y1 = info.origin[1] - info.spacing[1]/2;
+                let x4 = info.origin[0] + (info.size[0] - 0.5) * info.spacing[0];
+                let y4 = info.origin[1] + (info.size[1] - 0.5) * info.spacing[1];
+                let x2 = x1 + 0.25 * (x4 - x1), x3 = x1 + 0.75 * (x4 - x1);
+                let y2 = y1 + 0.25 * (y4 - y1), y3 = y1 + 0.75 * (y4 - y1);
                 traces.push({
                     type: 'scatter',
                     mode: 'lines',
                     hoverinfo: 'skip',
                     showlegend: false,
-                    x: [x0, x1, x1, x0, x0],
-                    y: [y0, y0, y1, y1, y0],
+                    x: [x1, x1, x2, null, x3, x4, x4, null, x4, x4, x3, null, x2, x1, x1],
+                    y: [y2, y1, y1, null, y1, y1, y2, null, y3, y4, y4, null, y4, y4, y3],
                     line: {color: info.color, width: 3}
                 });
             }

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -655,14 +655,18 @@ class VolumeSlicer:
 
             // Show our own color as a rectangle around the image,
             // But only if there are multiple slicers with the same scene id.
-            let shapes = [];
             if (indicators.length > 1) {
-                shapes.push({
-                    type: 'rect',
-                    //xref: 'paper', yref: 'paper', x0: 0, y0: 0, x1: 1, y1: 1,
-                    xref: 'x', yref: 'y',
-                    x0: info.origin[0] - info.spacing[0]/2, y0: info.origin[1] - info.spacing[1]/2,
-                    x1: info.origin[0] + (info.size[0] - 0.5) * info.spacing[0], y1: info.origin[1] + (info.size[1] - 0.5) * info.spacing[1],
+                let x0 = info.origin[0] - info.spacing[0]/2;
+                let y0 = info.origin[1] - info.spacing[1]/2;
+                let x1 = info.origin[0] + (info.size[0] - 0.5) * info.spacing[0];
+                let y1 = info.origin[1] + (info.size[1] - 0.5) * info.spacing[1];
+                traces.push({
+                    type: 'scatter',
+                    mode: 'lines',
+                    hoverinfo: 'skip',
+                    showlegend: false,
+                    x: [x0, x1, x1, x0, x0],
+                    y: [y0, y0, y1, y1, y0],
                     line: {color: info.color, width: 3}
                 });
             }
@@ -670,8 +674,6 @@ class VolumeSlicer:
             // Update figure
             let figure = {...ori_figure};
             figure.data = traces;
-            figure.layout.shapes = shapes;
-
             return figure;
         }
         """,

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -30,7 +30,9 @@ class VolumeSlicer:
       scene_id (str): the scene that this slicer is part of. Slicers
         that have the same scene-id show each-other's positions with
         line indicators. By default this is derived from ``id(volume)``.
-      color (str): the color for this slicer.
+      color (str): the color for this slicer. By default the color is
+        red, green, or blue, depending on the axis. Set to empty string
+        for "no color".
 
     This is a placeholder object, not a Dash component. The components
     that make up the slicer can be accessed as attributes. These must all
@@ -104,6 +106,10 @@ class VolumeSlicer:
             raise TypeError("scene_id must be a string")
         self._scene_id = scene_id
 
+        # Check color
+        if color is None:
+            color = ("red", "green", "blue")[self._axis]
+
         # Get unique id scoped to this slicer object
         VolumeSlicer._global_slicer_counter += 1
         self._context_id = "slicer" + str(VolumeSlicer._global_slicer_counter)
@@ -115,7 +121,7 @@ class VolumeSlicer:
             "size": shape3d_to_size2d(volume.shape, axis),
             "origin": shape3d_to_size2d(origin, axis),
             "spacing": shape3d_to_size2d(spacing, axis),
-            "color": color or "#00ffff",
+            "color": color,
         }
 
         # Build the slicer
@@ -651,11 +657,13 @@ class VolumeSlicer:
             // Collect traces
             let traces = [];
             for (let trace of img_traces) { traces.push(trace); }
-            for (let trace of indicators) { traces.push(trace); }
+            for (let trace of indicators) { if (trace.line.color) traces.push(trace); }
 
             // Show our own color as a rectangle around the image,
             // But only if there are multiple slicers with the same scene id.
-            if (indicators.length > 1) {
+
+            console.log(indicators.length)
+            if (indicators.length > 0 && info.color) {
                 let x1 = info.origin[0] - info.spacing[0]/2;
                 let y1 = info.origin[1] - info.spacing[1]/2;
                 let x4 = info.origin[0] + (info.size[0] - 0.5) * info.spacing[0];

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -383,7 +383,7 @@ class VolumeSlicer:
             [Input(self._state.id, "data")],
         )
         def upload_requested_slice(state):
-            if state is None:
+            if state is None or not state["index_changed"]:
                 return dash.no_update
             index = state["index"]
             slice = img_array_to_uri(self._slice(index))
@@ -510,15 +510,20 @@ class VolumeSlicer:
             // experience, and the interval can be set much lower.
             if (now - private_state.new_time >= interval) {
                 disable_timer = true;
-                console.log('requesting slice ' + index);
                 new_state = {
                     index: index,
+                    index_changed: false,
                     xrange: xrange,
                     yrange: yrange,
                     zpos: info.offset[2] + index * info.stepsize[2],
                     axis: info.axis,
                     color: info.color,
                 };
+                if (index != private_state.index) {
+                    private_state.index = index;
+                    new_state.index_changed = true;
+                    console.log('requesting slice ' + index);
+                }
             }
 
             return [new_state, disable_timer];
@@ -541,7 +546,6 @@ class VolumeSlicer:
                 State(self._graph.id, "figure"),
             ],
         )
-        # todo: bring back new store for req-slice
 
         # ----------------------------------------------------------------------
         # Callback that creates a list of image traces (slice and overlay).

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -1,5 +1,5 @@
 import numpy as np
-import plotly
+import plotly.graph_objects
 import dash
 from dash.dependencies import Input, Output, State, ALL
 from dash_core_components import Graph, Slider, Store, Interval
@@ -25,7 +25,7 @@ class VolumeSlicer:
         dimension (zyx).The spacing and origin are applied to make the slice
         drawn in "scene space" rather than "voxel space".
       origin (tuple of floats): The offset for each dimension (zyx).
-      axis (int): the dimension to slice in. The default 0.
+      axis (int): the dimension to slice in. Default 0.
       reverse_y (bool): Whether to reverse the y-axis, so that the origin of
         the slice is in the top-left, rather than bottom-left. Default True.
         Note: setting this to False affects performance, see #12.
@@ -172,8 +172,9 @@ class VolumeSlicer:
     @property
     def state(self):
         """A dcc.Store representing the current state of the slicer (present
-        in slicer.stores). Its data is a dict with the fields:
-        index (int), pos (float), axis (int), color (str).
+        in slicer.stores). Its data is a dict with the fields: index (int),
+        index_changed (bool), xrange (2 floats), yrange (2 floats),
+        zpos (float), axis (int), color (str).
 
         Its id is a dictionary so it can be used in a pattern matching Input.
         Fields: context, scene, name. Where scene is the scene_id and name is "state".
@@ -191,7 +192,7 @@ class VolumeSlicer:
     def create_overlay_data(self, mask, color=None):
         """Given a 3D mask array and an index, create an object that
         can be used as output for ``slicer.overlay_data``. The color
-        can be an rgb/rgba tuple, or a hex color. Alternatively, color
+        can be a hex color or an rgb/rgba tuple. Alternatively, color
         can be a list of such colors, defining a colormap.
         """
         # Check the mask

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -654,16 +654,7 @@ class VolumeSlicer:
         }
         """,
             Output(self._indicator_traces.id, "data"),
-            [
-                Input(
-                    {
-                        "scene": self._scene_id,
-                        "context": ALL,
-                        "name": "state",
-                    },
-                    "data",
-                )
-            ],
+            [Input({"scene": self._scene_id, "context": ALL, "name": "state"}, "data")],
             [State(self._info.id, "data")],
         )
 

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -28,10 +28,10 @@ spacing = 3, 2, 1
 ori = 1000, 2000, 3000
 
 
-slicer1 = VolumeSlicer(app, vol1, axis=1, origin=ori, scene_id="scene1")
-slicer2 = VolumeSlicer(app, vol1, axis=0, origin=ori, scene_id="scene1")
+slicer1 = VolumeSlicer(app, vol1, axis=1, origin=ori, scene_id="scene1", color="red")
+slicer2 = VolumeSlicer(app, vol1, axis=0, origin=ori, scene_id="scene1", color="green")
 slicer3 = VolumeSlicer(
-    app, vol2, axis=0, origin=ori, spacing=spacing, scene_id="scene1"
+    app, vol2, axis=0, origin=ori, spacing=spacing, scene_id="scene1", color="blue"
 )
 
 app.layout = html.Div(

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -8,6 +8,7 @@ import dash
 import dash_html_components as html
 import dash_core_components as dcc
 from dash_slicer import VolumeSlicer
+from dash.dependencies import Input, Output, State, ALL
 from skimage.measure import marching_cubes
 import imageio
 
@@ -21,11 +22,10 @@ slicer2 = VolumeSlicer(app, vol, axis=1)
 slicer3 = VolumeSlicer(app, vol, axis=2)
 
 # Calculate isosurface and create a figure with a mesh object
-verts, faces, _, _ = marching_cubes(vol, 300, step_size=2)
+verts, faces, _, _ = marching_cubes(vol, 300, step_size=4)
 x, y, z = verts.T
 i, j, k = faces.T
-fig_mesh = go.Figure()
-fig_mesh.add_trace(go.Mesh3d(x=z, y=y, z=x, opacity=0.2, i=k, j=j, k=i))
+mesh = go.Mesh3d(x=z, y=y, z=x, opacity=0.2, i=k, j=j, k=i)
 
 # Put everything together in a 2x2 grid
 app.layout = html.Div(
@@ -62,9 +62,45 @@ app.layout = html.Div(
             ]
         ),
         html.Div(
-            [html.Center(html.H1("3D")), dcc.Graph(id="graph-helper", figure=fig_mesh)]
+            [
+                html.Center(html.H1("3D")),
+                dcc.Graph(id="3Dgraph", figure=go.Figure(data=[mesh])),
+            ]
         ),
     ],
+)
+
+
+# Callback to display slicer view positions in the 3D view
+app.clientside_callback(
+    """
+function update_3d_figure(states, ori_figure) {
+    let traces = [ori_figure.data[0]]
+    for (let state of states) {
+        if (!state) continue;
+        let xrange = state.xrange;
+        let yrange = state.yrange;
+        let xyz = [
+            [xrange[0], xrange[1], xrange[1], xrange[0], xrange[0]],
+            [yrange[0], yrange[0], yrange[1], yrange[1], yrange[0]],
+            [state.zpos, state.zpos, state.zpos, state.zpos, state.zpos]
+        ];
+        xyz.splice(2 - state.axis, 0, xyz.pop());
+        let s = {
+            type: 'scatter3d',
+            x: xyz[0], y: xyz[1], z: xyz[2],
+            mode: 'lines', line: {color: state.color}
+        };
+        traces.push(s);
+    }
+    let figure = {...ori_figure};
+    figure.data = traces;
+    return figure;
+}
+    """,
+    Output("3Dgraph", "figure"),
+    Input({"scene": slicer1.scene_id, "context": ALL, "name": "state"}, "data"),
+    State("3Dgraph", "figure"),
 )
 
 

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -99,8 +99,8 @@ function update_3d_figure(states, ori_figure) {
 }
     """,
     Output("3Dgraph", "figure"),
-    Input({"scene": slicer1.scene_id, "context": ALL, "name": "state"}, "data"),
-    State("3Dgraph", "figure"),
+    [Input({"scene": slicer1.scene_id, "context": ALL, "name": "state"}, "data")],
+    [State("3Dgraph", "figure")],
 )
 
 

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -26,6 +26,9 @@ verts, faces, _, _ = marching_cubes(vol, 300, step_size=4)
 x, y, z = verts.T
 i, j, k = faces.T
 mesh = go.Mesh3d(x=z, y=y, z=x, opacity=0.2, i=k, j=j, k=i)
+fig = go.Figure(data=[mesh])
+fig.update_layout(uirevision="anything")  # prevent orientation reset on update
+
 
 # Put everything together in a 2x2 grid
 app.layout = html.Div(
@@ -64,7 +67,7 @@ app.layout = html.Div(
         html.Div(
             [
                 html.Center(html.H1("3D")),
-                dcc.Graph(id="3Dgraph", figure=go.Figure(data=[mesh])),
+                dcc.Graph(id="3Dgraph", figure=fig),
             ]
         ),
     ],

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -16,9 +16,9 @@ server = app.server
 
 # Read volumes and create slicer objects
 vol = imageio.volread("imageio:stent.npz")
-slicer1 = VolumeSlicer(app, vol, axis=0, color="red")
-slicer2 = VolumeSlicer(app, vol, axis=1, color="green")
-slicer3 = VolumeSlicer(app, vol, axis=2, color="blue")
+slicer1 = VolumeSlicer(app, vol, axis=0)
+slicer2 = VolumeSlicer(app, vol, axis=1)
+slicer3 = VolumeSlicer(app, vol, axis=2)
 
 # Calculate isosurface and create a figure with a mesh object
 verts, faces, _, _ = marching_cubes(vol, 300, step_size=2)

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -16,9 +16,9 @@ server = app.server
 
 # Read volumes and create slicer objects
 vol = imageio.volread("imageio:stent.npz")
-slicer1 = VolumeSlicer(app, vol, axis=0)
-slicer2 = VolumeSlicer(app, vol, axis=1)
-slicer3 = VolumeSlicer(app, vol, axis=2)
+slicer1 = VolumeSlicer(app, vol, axis=0, color="red")
+slicer2 = VolumeSlicer(app, vol, axis=1, color="green")
+slicer3 = VolumeSlicer(app, vol, axis=2, color="blue")
 
 # Calculate isosurface and create a figure with a mesh object
 verts, faces, _, _ = marching_cubes(vol, 300, step_size=2)

--- a/examples/threshold_overlay.py
+++ b/examples/threshold_overlay.py
@@ -47,7 +47,7 @@ app.layout = html.Div(
 
 
 # Define colormap to make the lower threshold shown in yellow, and higher in red
-colormap = [(0, 0, 0, 0), (255, 255, 0, 50), (255, 0, 0, 100)]
+colormap = [(255, 255, 0, 50), (255, 0, 0, 100)]
 
 
 @app.callback(


### PR DESCRIPTION
* [x] Add `color` arg, eg  `VolumeSlicer(... color='red')`.
* [x] Draw a rectangle around the image in that color. (But only when other slicers are present.)
* [x] Other slicers draw indicators in that color.
* [x] Indicators are now across the image.
* [x] Decide on way to display the color of the current slicer. -> corners with slightly thicker lines.
* [x] What should the default color be -> different color for each axis based on a good colormap (e.g. D3).
* [x] Refactor to use one store less (combine "index" and "pos" into "state).
* [x] Also include (rate limited) axis ranges, so that the indicators can be drawn correctly when zoomed in.
* [x] Renamed some fields in the `info` store to avoid confusion with shape, sampling and origin.
* [x] Slicer colors are taken from a plotly colormap.
* [x] The `create_overlay_data()` method samples default colors from the same colormap. 
* [x] If a colormap is given to `create_overlay_data()`, the first element is used where mask is 1 (was 0).
* [x] Update slicer_with_3_views to show slicer view ranges in the 3D figure.
* [x] Find actual figure size via `gd._fullLayout.width` / `height`?
----

![afbeelding](https://user-images.githubusercontent.com/3015475/101168264-7a6f0a80-363b-11eb-8e4a-86984298c783.png)
