### PR TITLE
add thumbnail_size property

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -290,7 +290,10 @@ class VolumeSlicer:
             dragmode="pan",  # good default mode
         )
         fig.update_xaxes(
-            showgrid=False, showticklabels=False, zeroline=False, constrain="range",
+            showgrid=False,
+            showticklabels=False,
+            zeroline=False,
+            constrain="range",
         )
         fig.update_yaxes(
             showgrid=False,
@@ -303,7 +306,9 @@ class VolumeSlicer:
 
         # Create the graph (graph is a Dash component wrapping a Plotly figure)
         self._graph = Graph(
-            id=self._subid("graph"), figure=fig, config={"scrollZoom": True},
+            id=self._subid("graph"),
+            figure=fig,
+            config={"scrollZoom": True},
         )
 
         initial_index = info["size"][2] // 2
@@ -375,7 +380,8 @@ class VolumeSlicer:
         app = self._app
 
         @app.callback(
-            Output(self._server_data.id, "data"), [Input(self._index.id, "data")],
+            Output(self._server_data.id, "data"),
+            [Input(self._index.id, "data")],
         )
         def upload_requested_slice(slice_index):
             slice = img_array_to_uri(self._slice(slice_index))
@@ -441,7 +447,11 @@ class VolumeSlicer:
             Output(self._slider.id, "value"),
             [
                 Input(
-                    {"scene": self._scene_id, "context": ALL, "name": "setpos",},
+                    {
+                        "scene": self._scene_id,
+                        "context": ALL,
+                        "name": "setpos",
+                    },
                     "data",
                 )
             ],
@@ -496,7 +506,10 @@ class VolumeSlicer:
         """.replace(
                 "{{ID}}", self._context_id
             ),
-            [Output(self._index.id, "data"), Output(self._timer.id, "disabled"),],
+            [
+                Output(self._index.id, "data"),
+                Output(self._timer.id, "disabled"),
+            ],
             [Input(self._slider.id, "value"), Input(self._timer.id, "n_intervals")],
             [State(self._timer.id, "interval")],
         )
@@ -622,7 +635,10 @@ class VolumeSlicer:
                 )
                 for axis in self._other_axii
             ],
-            [State(self._info.id, "data"), State(self._indicator_traces.id, "data"),],
+            [
+                State(self._info.id, "data"),
+                State(self._indicator_traces.id, "data"),
+            ],
         )
 
         # ----------------------------------------------------------------------
@@ -649,5 +665,7 @@ class VolumeSlicer:
                 Input(self._img_traces.id, "data"),
                 Input(self._indicator_traces.id, "data"),
             ],
-            [State(self.graph.id, "figure"),],
+            [
+                State(self.graph.id, "figure"),
+            ],
         )

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -39,12 +39,12 @@ def test_slicer_thumbnail():
     app = dash.Dash()
     vol = np.random.uniform(0, 255, (100, 100, 100)).astype(np.uint8)
 
-    s = VolumeSlicer(app, vol)
+    _ = VolumeSlicer(app, vol)
     # Test for name pattern of server-side callback when thumbnails are used
     assert any(["server-data.data" in key for key in app.callback_map])
 
     app = dash.Dash()
-    s = VolumeSlicer(app, vol, thumbnail=False)
+    _ = VolumeSlicer(app, vol, thumbnail=False)
     # No server-side callbacks when no thumbnails are used
     assert not any(["server-data.data" in key for key in app.callback_map])
 

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -21,6 +21,10 @@ def test_slicer_init():
     with raises(ValueError):
         VolumeSlicer(app, vol, axis=4)
 
+    # Need a valide thumbnail_size
+    with raises(ValueError):
+        VolumeSlicer(app, vol, thumbnail_size=20.2)
+
     # This works
     s = VolumeSlicer(app, vol)
 

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -21,9 +21,9 @@ def test_slicer_init():
     with raises(ValueError):
         VolumeSlicer(app, vol, axis=4)
 
-    # Need a valide thumbnail_size
+    # Need a valide thumbnail
     with raises(ValueError):
-        VolumeSlicer(app, vol, thumbnail_size=20.2)
+        VolumeSlicer(app, vol, thumbnail=20.2)
 
     # This works
     s = VolumeSlicer(app, vol)

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -35,6 +35,20 @@ def test_slicer_init():
     assert all(isinstance(store, (dcc.Store, dcc.Interval)) for store in s.stores)
 
 
+def test_slicer_thumbnail():
+    app = dash.Dash()
+    vol = np.random.uniform(0, 255, (100, 100, 100)).astype(np.uint8)
+
+    s = VolumeSlicer(app, vol)
+    # Test for name pattern of server-side callback when thumbnails are used
+    assert any(["server-data.data" in key for key in app.callback_map])
+
+    app = dash.Dash()
+    s = VolumeSlicer(app, vol, thumbnail=False)
+    # No server-side callbacks when no thumbnails are used
+    assert not any(["server-data.data" in key for key in app.callback_map])
+
+
 def test_scene_id_and_context_id():
     app = dash.Dash()
 


### PR DESCRIPTION
[Updated]

This PR introduces a `thumbnail_size` property of the slicer, in order to be able to choose the size of the low-resolution images uploaded and available clientside.  It is an integer, or None, in which case the full resolution data is uploaded clientside (I implemented this by not attaching the server callback, which was an easy solution).

 