### PR TITLE
A few fixes and performance tweaks

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -737,6 +737,7 @@ class VolumeSlicer:
                 State(self._info.id, "data"),
                 State(self._state.id, "data"),
             ],
+            prevent_initial_call=True,
         )
 
         # ----------------------------------------------------------------------

--- a/dash_slicer/utils.py
+++ b/dash_slicer/utils.py
@@ -18,15 +18,23 @@ def img_as_ubyte(img):
         return img.astype(np.uint8)
 
 
-def img_array_to_uri(img_array, new_size=None):
+def _thumbnail_size_from_scalar(image_size, ref_size):
+    if image_size[0] > image_size[1]:
+        return int(ref_size * image_size[0] / image_size[1]), ref_size
+    else:
+        return ref_size, int(ref_size * image_size[1] / image_size[0])
+
+
+def img_array_to_uri(img_array, ref_size=None):
     """Convert the given image (numpy array) into a base64-encoded PNG."""
     img_array = img_as_ubyte(img_array)
     # todo: leverage this Plotly util once it becomes part of the public API (also drops the Pillow dependency)
     # from plotly.express._imshow import _array_to_b64str
     # return _array_to_b64str(img_array)
     img_pil = PIL.Image.fromarray(img_array)
-    if new_size:
-        img_pil.thumbnail(new_size)
+    if ref_size:
+        size = img_array.shape[1], img_array.shape[0]
+        img_pil.thumbnail(_thumbnail_size_from_scalar(size, ref_size))
     # The below was taken from plotly.utils.ImageUriValidator.pil_image_to_uri()
     f = io.BytesIO()
     img_pil.save(f, format="PNG")
@@ -34,13 +42,15 @@ def img_array_to_uri(img_array, new_size=None):
     return "data:image/png;base64," + base64_str
 
 
-def get_thumbnail_size(size, new_size):
+def get_thumbnail_size(size, ref_size):
     """Given an image size (w, h), and a preferred smaller size,
     get the actual size if we let Pillow downscale it.
     """
+    # Note that if you call thumbnail() to get the resulting size, then call
+    # thumbnail() again with that size, the result may be yet another size.
     img_array = np.zeros(list(reversed(size)), np.uint8)
     img_pil = PIL.Image.fromarray(img_array)
-    img_pil.thumbnail(new_size)
+    img_pil.thumbnail(_thumbnail_size_from_scalar(size, ref_size))
     return img_pil.size
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,8 +31,8 @@ def test_img_array_to_uri():
     im = np.random.uniform(0, 255, (100, 100)).astype(np.uint8)
 
     r1 = img_array_to_uri(im)
-    r2 = img_array_to_uri(im, (32, 32))
-    r3 = img_array_to_uri(im, (8, 8))
+    r2 = img_array_to_uri(im, 32)
+    r3 = img_array_to_uri(im, 8)
 
     for r in (r1, r2, r3):
         assert isinstance(r, str)
@@ -43,9 +43,10 @@ def test_img_array_to_uri():
 
 def test_get_thumbnail_size():
 
-    assert get_thumbnail_size((100, 100), (16, 16)) == (16, 16)
-    assert get_thumbnail_size((50, 100), (16, 16)) == (8, 16)
-    assert get_thumbnail_size((100, 100), (8, 16)) == (8, 8)
+    assert get_thumbnail_size((100, 100), 16) == (16, 16)
+    assert get_thumbnail_size((50, 100), 16) == (16, 32)
+    assert get_thumbnail_size((100, 100), 8) == (8, 8)
+    assert get_thumbnail_size((100, 50), 8) == (16, 8)
 
 
 def test_shape3d_to_size2d():


### PR DESCRIPTION
* Due to a bug, the rate limiting did not happen for layout changes like zooming and panning.
* Also made the rate limiting timeout larger for layout changes, because scroll zoom quickly feels jerky otherwise.
* Fix the sometimes weird initialization by preventing initial calls for one callback.
* When the image is larger in one dimension than in another, the thumbnails would be small in the smaller dimension. Changed so that the given size means the *minimal* size.
* Also fixed a bug that the stored thumbnail size would sometimes be wrong.
* Renamed lowres to thumbnail, because it can also contain fullres data.