### PR TITLE
Fixing plotly/dash-slicer#59

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dash-slicer depends on Python 3.6+ plus some [dependencies](requirements.txt).
 
 ```py
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
 import imageio
 

--- a/dash_slicer/__init__.py
+++ b/dash_slicer/__init__.py
@@ -2,7 +2,6 @@
 dash_slicer - a volume slicer for Dash
 """
 
-
 from .slicer import VolumeSlicer  # noqa: F401
 
 

--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -83,7 +83,7 @@ import numpy as np
 import plotly.graph_objects
 import dash
 from dash.dependencies import Input, Output, State, ALL
-from dash_core_components import Graph, Slider, Store, Interval
+from dash.dcc import Graph, Slider, Store, Interval
 
 from .utils import (
     discrete_colors,

--- a/examples/all_features.py
+++ b/examples/all_features.py
@@ -4,8 +4,8 @@ An example that is (tries to be) a demo of all features.
 
 import plotly.graph_objects as go
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash_slicer import VolumeSlicer
 from dash.dependencies import Input, Output, State, ALL
 import imageio

--- a/examples/bring_your_own_slider.py
+++ b/examples/bring_your_own_slider.py
@@ -7,8 +7,8 @@ dimensions. The slider element itself is hidden.
 """
 
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output
 from dash_slicer import VolumeSlicer
 import imageio

--- a/examples/contrast.py
+++ b/examples/contrast.py
@@ -3,8 +3,8 @@ A small example demonstrating contrast limits.
 """
 
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output
 from dash_slicer import VolumeSlicer
 import imageio

--- a/examples/set_slicer_position_interactively.py
+++ b/examples/set_slicer_position_interactively.py
@@ -4,9 +4,9 @@ by listening to the "drag_value" of the default slider with an auxiliary slider
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
-import dash_core_components as dcc
+from dash import dcc
 from dash.dependencies import Input, Output
 import imageio
 

--- a/examples/set_slicer_position_simple.py
+++ b/examples/set_slicer_position_simple.py
@@ -5,9 +5,9 @@ See set_slicer_position_interactively.py for a more advanced / realistic example
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
-import dash_core_components as dcc
+from dash import dcc
 from dash.dependencies import Input, Output, ALL
 import imageio
 

--- a/examples/slicer_customized.py
+++ b/examples/slicer_customized.py
@@ -4,8 +4,8 @@ involving the slicer's components.
 """
 
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output, State
 from dash_slicer import VolumeSlicer
 import imageio

--- a/examples/slicer_with_1_plus_2_views.py
+++ b/examples/slicer_with_1_plus_2_views.py
@@ -14,7 +14,7 @@ Note how the indicators represent the actual position in "scene coordinates".
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
 import imageio
 

--- a/examples/slicer_with_1_view.py
+++ b/examples/slicer_with_1_view.py
@@ -3,7 +3,7 @@ A truly minimal example.
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
 import imageio
 

--- a/examples/slicer_with_2_views.py
+++ b/examples/slicer_with_2_views.py
@@ -3,7 +3,7 @@ An example with two slicers on the same volume.
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
 import imageio
 

--- a/examples/slicer_with_3_views.py
+++ b/examples/slicer_with_3_views.py
@@ -5,8 +5,8 @@ in medical applications. In the fourth quadrant we put an isosurface mesh.
 
 import plotly.graph_objects as go
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash_slicer import VolumeSlicer
 from dash.dependencies import Input, Output, State, ALL
 from skimage.measure import marching_cubes

--- a/examples/threshold_contour.py
+++ b/examples/threshold_contour.py
@@ -7,8 +7,8 @@ property is used to add scatter traces that represent the contours.
 
 import plotly
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output
 from dash_slicer import VolumeSlicer
 import imageio

--- a/examples/threshold_overlay.py
+++ b/examples/threshold_overlay.py
@@ -7,8 +7,8 @@ to the image data.
 """
 
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output
 from dash_slicer import VolumeSlicer
 import numpy as np

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ pillow
 numpy
 plotly
 dash
-dash_core_components

--- a/test_deploy/app.py
+++ b/test_deploy/app.py
@@ -3,7 +3,7 @@ An example with two slicers on the same volume.
 """
 
 import dash
-import dash_html_components as html
+from dash import html
 from dash_slicer import VolumeSlicer
 import imageio
 

--- a/tests/performance1.py
+++ b/tests/performance1.py
@@ -4,8 +4,8 @@ A test application to test the performance of a few methods to display an image.
 
 import plotly.graph_objects as go
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output, State
 import imageio
 from dash_slicer.utils import img_array_to_uri

--- a/tests/performance2.py
+++ b/tests/performance2.py
@@ -5,8 +5,8 @@ slicing through a volume using a slider.
 
 import plotly.graph_objects as go
 import dash
-import dash_html_components as html
-import dash_core_components as dcc
+from dash import html
+from dash import dcc
 from dash.dependencies import Input, Output, State
 import imageio
 from dash_slicer.utils import img_array_to_uri

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -3,7 +3,7 @@ from dash_slicer import VolumeSlicer
 import numpy as np
 from pytest import raises
 import dash
-import dash_core_components as dcc
+from dash import dcc
 
 
 def test_slicer_init():


### PR DESCRIPTION
All deprecated imports replaced.