### PR TITLE
bump version and fix ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   deploy_to_playground:
     docker:
-      - image: circleci/python:3.6-stretch
+      - image: circleci/python:3.12-stretch
     steps:
       - checkout
       - run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - name: Linux py36
-            os: ubuntu-16.04
-            pyversion: '3.6'
           - name: Linux py37
             os: ubuntu-latest
             pyversion: '3.7'
@@ -27,12 +25,21 @@ jobs:
           - name: Linux py39
             os: ubuntu-latest
             pyversion: '3.9'
-          - name: MacOS py38
+          - name: Linux py310
+            os: ubuntu-latest
+            pyversion: '3.10'
+          - name: Linux py311
+            os: ubuntu-latest
+            pyversion: '3.11'
+          - name: Linux py312
+            os: ubuntu-latest
+            pyversion: '3.12'
+          - name: MacOS py312
             os: macos-latest
-            pyversion: '3.8'
-          - name: Windows py38
+            pyversion: '3.12'
+          - name: Windows py312
             os: windows-latest
-            pyversion: '3.8'
+            pyversion: '3.12'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Linux py37
-            os: ubuntu-latest
-            pyversion: '3.7'
           - name: Linux py38
             os: ubuntu-latest
             pyversion: '3.8'

--- a/dash_slicer/__init__.py
+++ b/dash_slicer/__init__.py
@@ -5,5 +5,5 @@ dash_slicer - a volume slicer for Dash
 from .slicer import VolumeSlicer  # noqa: F401
 
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 version_info = tuple(map(int, __version__.split(".")))

--- a/dash_slicer/utils.py
+++ b/dash_slicer/utils.py
@@ -81,7 +81,7 @@ def mask_to_coloured_slices(mask, axis, color=None):
     # Check the mask
     if not isinstance(mask, np.ndarray):
         raise TypeError("Mask must be an ndarray or None.")
-    elif mask.dtype not in (np.bool, np.uint8):
+    elif mask.dtype not in (bool, np.uint8):
         raise ValueError(f"Mask must have bool or uint8 dtype, not {mask.dtype}.")
 
     mask = mask.astype(np.uint8, copy=False)  # need int to index


### PR DESCRIPTION
* Bump version.
* Fixed a small bug (we used np.bool but that's deprecated).
* Update CI to test for py38 -py312.  (dropped 3.7 out of convenience, because black on py37 behaves differently).  
* I *did not* fix the CI build for circle-ci, because my bandwith is limited and I don't feel like looking into expired credentials right now 🤷   