### PR TITLE
Add slider step and marks to VolumeSlicer constructor

### DIFF
--- a/dash_slicer/slicer.py
+++ b/dash_slicer/slicer.py
@@ -146,6 +146,8 @@ class VolumeSlicer:
         scene_id=None,
         color=None,
         thumbnail=True,
+        step=1,
+        marks=None,
     ):
 
         if not isinstance(app, dash.Dash):
@@ -230,7 +232,7 @@ class VolumeSlicer:
             )
 
         # Build the slicer
-        self._create_dash_components()
+        self._create_dash_components(step, marks)
         self._create_server_callbacks()
         self._create_client_callbacks()
 
@@ -363,7 +365,7 @@ class VolumeSlicer:
         im[im > 255] = 255
         return im.astype(np.uint8)
 
-    def _create_dash_components(self):
+    def _create_dash_components(self, step, marks):
         """Create the graph, slider, figure, etc."""
         info = self._slice_info
 
@@ -404,10 +406,11 @@ class VolumeSlicer:
             id=self._subid("slider"),
             min=0,
             max=info["size"][2] - 1,
-            step=1,
+            step=step,
             value=info["size"][2] // 2,
             updatemode="drag",
             tooltip={"always_visible": False, "placement": "left"},
+            marks=marks,
         )
 
         # Create the stores that we need (these must be present in the layout)


### PR DESCRIPTION
By default the slider step is set to 1, which causes the slider marks to be crowded for images with many slices. 

Here is an example from the [Slicer docs](https://dash.plotly.com/slicer):
![image](https://github.com/user-attachments/assets/e8def6b9-a004-43c6-afd3-7f456e93cf9d)

I added the Slider step and marks arguments to the VolumeSlicer constructor so users can modify it as needed.

I also set the default value of marks to None so that no marks are added by default. 